### PR TITLE
bugfix: pass along all actions to next middleware in chain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,9 +35,9 @@ const createWorkerMiddleware = (worker) => {
     return (action) => {
       if (action.meta && action.meta.WebWorker) {
         worker.postMessage(action);
-      } else {
-        return next(action);
       }
+      // always pass the action along to the next middleware
+      return next(action);
     };
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,19 @@ const createWorkerMiddleware = (worker) => {
     the first argument is ({ dispatch, getState }) by default,
     but we don't actually need them for now.
   */
-  return () => (next) => {
+  return ({ dispatch }) => (next) => {
     if (!next) {
       console.error( // eslint-disable-line no-console
         'Fatal: worker middleware received no `next` action. Check your chain of middlewares.'
       );
     }
 
-    worker.onmessage = ({ data: action }) => { // eslint-disable-line no-param-reassign
-      next(action);
+    /*
+      when the worker posts a message back, dispatch the action with its payload
+      so that it will go through the entire middleware chain
+    */
+    worker.onmessage = ({ data: resultAction }) => { // eslint-disable-line no-param-reassign
+      dispatch(resultAction);
     };
 
     return (action) => {

--- a/test/__setup__/workerPolyfill.js
+++ b/test/__setup__/workerPolyfill.js
@@ -1,17 +1,13 @@
-import { idFn } from '../utils';
-
 export class Worker {
-  constructor(fn = idFn) {
+  constructor(fn = () => (3)) {
     this.fn = fn;
   }
 
   postMessage = (msg) => {
-    if (this.onmessage) {
-      setTimeout(() => {
-        const data = this.fn(msg);
-        this.onmessage({ data });
-      }, 0);
-    }
+    setTimeout(() => {
+      const data = this.fn(msg);
+      this.onmessage({ data });
+    }, 5);
   };
 
   onmessage = undefined;

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,2 +1,0 @@
-export const noop = () => {}; // eslint-disable-line arrow-body-style
-export const idFn = (x) => x;


### PR DESCRIPTION
Here it is at last, the fix for #4! Thanks again for giving me the nudge @c-h-, this has been in the back of my mind to finish up for _so long_.

There were actually two bugs/exceptions to the general middleware pattern going on before:

1. An action with the Worker properties didn't get passed along to any following middlewares in the chain.
1. An action returned from the Worker was being passed along the chain with `next` instead of being dispatched as a new action, so it was only passing through the following links in the middleware chain rather than all of them; this had the potential to be a very large bug for anyone trying to dispatch some kind of a fetch request (or anything needing to be picked up by a middleware at the top of the chain) via the Worker's response.

I had to access the `dispatch` from the `store` at the top level of the layers of function currying in order to fix the second issue, so I added some testing around that as well, naturally. This resulted in problems with the `setTimeout(fn, 0)` strategy being used in the Worker polyfill, so I've updated the polyfill strategy a bit in a way that I _believe_ makes sense, and I had to use `setTimeout` in some of the tests. (Alternatively mock timers could be used in the tests, but I don't think `expect` has that functionality? I'm more accustomed to working with Chai + Sinon myself.) The tests and modifications to the polyfill are probably where I'd spend the most time reviewing, to make sure I didn't miss anything!

Probably not necessary, but just to illustrate how these changes had an effect on an existing app. Here is the redux-logger operating *after* the worker middleware in the chain using the current version of redux-worker-middleware (without my fixes):
![screenshot 2017-02-15 16 35 41](https://cloud.githubusercontent.com/assets/1588547/23001977/09efe3fe-f39d-11e6-8096-dcae9b164463.png)

Note here that there are no `DATA_PROCESS_REQUEST` actions logged (those are the ones with the Worker `meta` properties that get dropped from the chain). The `DATA_PROCESS_SUCCESS` are the actions returned by the Worker.

Now here is the same fetch and data processing sequence when I locally `npm link` my clone of the redux-worker-middleware *with* the fixes:

![screenshot 2017-02-15 16 40 35](https://cloud.githubusercontent.com/assets/1588547/23002068/83330700-f39d-11e6-93a7-5b56d57972dc.png)

Observe that we have two `FETCH_DATA_SUCCESS`, which each trigger a `DATA_PROCESS_REQUEST` (the action with Worker `meta` properties, which now we see logged instead of dropped), and also the `DATA_PROCESS_SUCCESS` are still there (though now from `dispatch` to the top of the middlewares chain rather than just going through the remainder of the chain with `next`).

(Ignore all the `FETCH_DATA_SPAN` and `INITIALIZE_DOMAIN` stuff intervening in there...those requests were slower in the first screenshot because the server hadn't cached them yet...😛  Also the dispatching of the Worker-generated result action to the top of the chain may be changing the sequence of things happening/getting logged. There's **a lot** of async data fetching and processing going on in this app.)
